### PR TITLE
fix: Address WAVE tool issues

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,9 +14,9 @@
     <h2 class="login-instructions" id="loginInstructions">Please sign in to view your Dashboard</h2>
     <p class="error-message" id="errorMessage"></p>
     <label for="username">User Name</label><br>
-    <input type="text" placeholder="Enter username" id="username" name="username" required><br>
+    <input id="username" type="text" placeholder="Enter username" required><br>
     <label for="password">Password</label><br>
-    <input type="text" placeholder="Enter password" id="password" name="password" required><br>
+    <input id="password" type="password" placeholder="Enter password" required><br>
     <button type="submit" id="loginButton">Login</button>
   </form>
   <main class="dashboard hidden" id="travelerDashboard">
@@ -45,17 +45,17 @@
     </section>
     <form class="single create-trip-request" id="tripRequestForm">
       <h2>Submit Trip Request</h2>
-      <label for="start-date">When would you like to leave?</label>
-      <input type="date" placeholder="Start Date" id="startDate" name="startDate" required>
+      <label for="startDate">When would you like to leave?</label>
+      <input id="startDate" type="date" required>
       <label for="duration">How long would you like to stay?</label>
-      <input type="number" name="duration" placeholder="1" min="1" id="duration" required>
-      <label for="travelers">How many in your party?</label>
-      <input type="number" name="numberOfTravelers" placeholder="1" min="1" id="numOfTravelers" required>
+      <input id="duration" type="number" placeholder="1" min="1"  required>
+      <label for="numOfTravelers">How many in your party?</label>
+      <input id="numOfTravelers" type="number" placeholder="1" min="1"  required>
       <label for="destinations">Where would you like to go?</label>
       <select name="destinations" id="destinations" required>
         <option value="" disabled selected>Select your destination</option>
       </select>
-      <h3 id="estimatedTripCost"></h3>
+      <p class="estimated-trip-cost" id="estimatedTripCost"></p>
       <button type="submit" id="tripRequestSubmitButton">Submit Trip Request</button>
     </form>
   </main>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -70,6 +70,10 @@ ul {
   list-style-type: none;
 }
 
+.estimated-trip-cost {
+  font-weight: bold;
+}
+
 .error-message {
   color: red;
 }

--- a/src/dom-updates.js
+++ b/src/dom-updates.js
@@ -49,7 +49,7 @@ const updatePastTripsList = (currentTravelerCompleteTrips) => {
   })
 
   const currentTravelerPastTrip = dateCheckedTrips.map(trip =>
-    `<li><img src="${trip.destinationImage}" alt="Image of ${trip.destination}" width="100%" height="auto"><p>${trip.tripDate}: ${trip.tripDuration} days in ${trip.destination}</p></li>`).join('<br>');
+    `<li><img src="${trip.destinationImage}" alt="${trip.destination}" width="100%" height="auto"><p>${trip.tripDate}: ${trip.tripDuration} days in ${trip.destination}</p></li>`).join('<br>');
 
   if (!currentTravelerPastTrip) {
     pastTripsList.innerHTML = `<li>You currently have no past trips.</li>`;
@@ -70,7 +70,7 @@ const updatePendingTripsList = (currentTravelerCompleteTrips) => {
   })
 
   const currentTravelerPendingTrip = dateCheckedTrips.map(trip =>
-    `<li><img src="${trip.destinationImage}" alt="Image of ${trip.destination}" width="100%" height="auto"><p>${trip.tripDate}: ${trip.tripDuration} days in ${trip.destination}</p></li>`).join('<br>');
+    `<li><img src="${trip.destinationImage}" alt="${trip.destination}" width="100%" height="auto"><p>${trip.tripDate}: ${trip.tripDuration} days in ${trip.destination}</p></li>`).join('<br>');
 
   if (!currentTravelerPendingTrip) {
     pendingTripsList.innerHTML = `<li>You currently have no pending trips.</li>`;
@@ -91,7 +91,7 @@ const updateUpcomingTripsList = (currentTravelerCompleteTrips) => {
   })
 
   const currentTravelerPastTrip = dateCheckedTrips.map(trip =>
-    `<li><img src="${trip.destinationImage}" alt="Image of ${trip.destination}" width="100%" height="auto"><p>${trip.tripDate}: ${trip.tripDuration} days in ${trip.destination}</p></li>`).join('<br>');
+    `<li><img src="${trip.destinationImage}" alt="${trip.destination}" width="100%" height="auto"><p>${trip.tripDate}: ${trip.tripDuration} days in ${trip.destination}</p></li>`).join('<br>');
 
   if (!currentTravelerPastTrip) {
     upcomingTripsList.innerHTML = `<li>You currently have no upcoming trips.</li>`;


### PR DESCRIPTION
# Description
- Add fixes for all WAVE tool issues 
- Caveat below

# Screenshot(s)
When I run the WAVE tool on the login page:
![Image](https://github.com/ericahagle/travel-tracker/assets/133910120/f8d3a046-2188-491c-8f8f-ad71b962543d)

When I run the WAVE tool after logging in:
![Image](https://github.com/ericahagle/travel-tracker/assets/133910120/8765b6b0-55ca-4ef6-9132-25aad77c27e6)

# Notes
- For some reason, I get passing grades on the login form when I'm ON the login form, but if I run the wave tool after logging in, it's showing errors. I can't figure out why.
- If I run the WAVE tool on login, then log in while it's still up, everything looks fine on the main content page. 
- I'm considering this as ok—can address in the future if necessary.

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] fix: My PR clearly describes what bug I'm fixing and why.